### PR TITLE
Fix the layout issue

### DIFF
--- a/TestTextureCell/MultipleStateCell.swift
+++ b/TestTextureCell/MultipleStateCell.swift
@@ -66,7 +66,6 @@ class MultipleStateCell: ASCellNode {
 	@objc func stateChanged() {
 		self.state = self.state.toggle()
 		self.transitionLayout(withAnimation: true, shouldMeasureAsync: false, measurementCompletion: nil)
-		self.setNeedsLayout()
 	}
 
 


### PR DESCRIPTION
After https://github.com/TextureGroup/Texture/pull/808, you just need to call `transitionLayout` and the layout change should be animated correctly using the default animation. To implement a custom layout, please check [this](http://texturegroup.org/docs/layout-transition-api.html) out. Cheers!